### PR TITLE
Disable shared memory to prevent crashes, use new headless mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ CMD [ \
 # Disable cross-origin safeguards
 "--disable-web-security", \
 # Run in headless mode
-"--headless", \
+"--headless=new", \
 # Hide scrollbars on generated images/PDFs
 "--hide-scrollbars", \
 # Disable reporting to UMA, but allows for collection
@@ -92,5 +92,7 @@ CMD [ \
 # Disable fetching safebrowsing lists, likely redundant due to disable-background-networking
 "--safebrowsing-disable-auto-update", \
 # Make use of user data directory
-"--user-data-dir" \
+"--user-data-dir", \
+# Disable shared memory to prevent crashes
+"--disable-dev-shm-usage" \
 ]


### PR DESCRIPTION
Updates the command in the Dockerfile to add the `--disable-dev-shm-usage ` option. Also, uses `--headless=new` for the updated headless mode available since version 112: https://developer.chrome.com/articles/new-headless/

This branch requires a new build of the Docker image in order to update Chromium to 117, which makes the new headless mode available. It has been pushed to: https://hub.docker.com/r/byrond/chrome-headless/tags

That Docker image is being tested on a client project.

## To do
- Come up with a versioning scheme and push a `latest` tag.
- Create a Docker Hub account and push images there instead of a personal account.